### PR TITLE
feat: better changelog messages for mediawiki

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,4 +78,8 @@ jobs:
         env:
           MEDIAWIKI_USERNAME: ${{ vars.MEDIAWIKI_USERNAME }}
           MEDIAWIKI_PASSWORD: ${{ secrets.MEDIAWIKI_PASSWORD }}
+          GITHUB_EVENT_HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: pnpm deploy-mediawiki


### PR DESCRIPTION
Update the MediaWiki integration to use detailed changelog messages like this:

```
Use Pino for backend logging (#4) by @mplewis - https://github.com/mplewis/dominion-strategy-wiki/commit/8d9ef9c23d115d00950b83e57ebbf128cfde1497
```