### PR TITLE
Structured cost parsing

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -21,6 +21,7 @@
 			"Bash(node:*)",
 			"Bash(touch:*)"
 		],
-		"deny": []
+		"deny": [],
+		"defaultMode": "acceptEdits"
 	}
 }

--- a/src/dev/api/services/cache.ts
+++ b/src/dev/api/services/cache.ts
@@ -1,6 +1,6 @@
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 
 /** Gets the system-appropriate cache directory based on the current platform */
 function getSystemCacheDir(): string {

--- a/src/dev/api/services/scraper.ts
+++ b/src/dev/api/services/scraper.ts
@@ -1,4 +1,5 @@
-import axios, { type AxiosResponse } from "axios";
+import type { AxiosResponse } from "axios";
+import * as axios from "axios";
 import * as cheerio from "cheerio";
 import cacheService from "./cache.js";
 

--- a/src/scripts/scrape-all-card-cost-classes.ts
+++ b/src/scripts/scrape-all-card-cost-classes.ts
@@ -1,0 +1,42 @@
+// Scrape all card classes from the wiki and save to tmp/cost-classes.json.
+// Run with `pnpx tsx src/scripts/scrape-all-card-cost-classes.ts`
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as cheerio from "cheerio";
+import { fetchWikiPage, getAvailableCardSets } from "../dev/api/services/scraper.js";
+
+const reCost = /^cost(\$)?(\d\d)?([*+])?((\d\d)[Dd])?([Pp])?$/i;
+
+async function scrapeAllCardCostClasses(): Promise<string[]> {
+	const cardSets = getAvailableCardSets();
+	console.log(`Scraping ${cardSets.length} card sets...`);
+
+	const allCostClasses = new Set<string>();
+	for (const cardSet of cardSets) {
+		console.log(`Processing ${cardSet.name}...`);
+		const pageData = await fetchWikiPage(cardSet.url);
+		const $ = cheerio.load(pageData.content);
+		$(".cardcost").each((_i, element) => {
+			const classList = $(element).attr("class")?.split(/\s+/) || [];
+			for (const className of classList) {
+				if (reCost.test(className)) allCostClasses.add(className);
+			}
+		});
+	}
+	return Array.from(allCostClasses).sort();
+}
+
+async function main(): Promise<void> {
+	console.log("Starting card cost class scraping...");
+	const costClasses = await scrapeAllCardCostClasses();
+
+	console.log(`Found ${costClasses.length} unique cost classes:`);
+	console.log(JSON.stringify(costClasses, null, 2));
+
+	const outputPath = path.join(process.cwd(), "tmp", "cost-classes.json");
+	await fs.writeFile(outputPath, JSON.stringify(costClasses, null, 2));
+	console.log(`Results written to ${outputPath}`);
+}
+
+main();

--- a/src/wiki/cards/cost-parser.test.ts
+++ b/src/wiki/cards/cost-parser.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { compareParsedCosts, parseCostString } from "./cost-parser.js";
+
+// Scraped from all expansion pages on the wiki on 2025-08-16
+const WIKI_COST_CLASSES = [
+	"cost",
+	"cost$00",
+	"cost$00*",
+	"cost$0004D",
+	"cost$0005D",
+	"cost$0006D",
+	"cost$0008D",
+	"cost$00P",
+	"cost$01",
+	"cost$02",
+	"cost$02*",
+	"cost$02+",
+	"cost$02P",
+	"cost$03",
+	"cost$03*",
+	"cost$03+",
+	"cost$03P",
+	"cost$04",
+	"cost$04*",
+	"cost$04+",
+	"cost$0403D",
+	"cost$04P",
+	"cost$05",
+	"cost$05*",
+	"cost$06",
+	"cost$06*",
+	"cost$06P",
+	"cost$07",
+	"cost$07*",
+	"cost$08",
+	"cost$08*",
+	"cost$0808D",
+	"cost$09",
+	"cost$10",
+	"cost$11",
+	"cost$14",
+];
+
+describe("parseCostString", () => {
+	describe("multiple string inputs", () => {
+		it("returns first matching cost class", () => {
+			const result = parseCostString("landscape", "cost$05", "cost$03", "set09");
+			expect(result?.coinCost).toBe(5);
+		});
+
+		it("returns null if no cost classes found", () => {
+			const result = parseCostString("landscape", "cardname", "set09");
+			expect(result).toBeNull();
+		});
+	});
+
+	it.each([
+		{
+			desc: "simple coin costs",
+			input: "cost$05",
+			expected: { coinCost: 5, debtCost: 0, hasPotion: false, modifier: null },
+		},
+		{
+			desc: "potion costs",
+			input: "cost$03P",
+			expected: { coinCost: 3, debtCost: 0, hasPotion: true, modifier: null },
+		},
+		{
+			desc: "variable costs with +",
+			input: "cost$02+",
+			expected: { coinCost: 2, debtCost: 0, hasPotion: false, modifier: "+" },
+		},
+		{
+			desc: "variable costs with *",
+			input: "cost$06*",
+			expected: { coinCost: 6, debtCost: 0, hasPotion: false, modifier: "*" },
+		},
+		{
+			desc: "debt costs",
+			input: "cost$0008D",
+			expected: { coinCost: 0, debtCost: 8, hasPotion: false, modifier: null },
+		},
+		{
+			desc: "coin + debt costs",
+			input: "cost$0403D",
+			expected: { coinCost: 4, debtCost: 3, hasPotion: false, modifier: null },
+		},
+		{
+			desc: "cost with no coin amount",
+			input: "cost",
+			expected: { coinCost: 0, debtCost: 0, hasPotion: false, modifier: null },
+		},
+		{
+			desc: "zero cost",
+			input: "cost$00",
+			expected: { coinCost: 0, debtCost: 0, hasPotion: false, modifier: null },
+		},
+	])("parses $desc", ({ input, expected }) => {
+		const result = parseCostString(input);
+		expect(result).toEqual(expected);
+	});
+
+	it("parses all cost classes from the wiki", () => {
+		WIKI_COST_CLASSES.forEach((costClass) => {
+			const result = parseCostString(costClass);
+			expect(result).toHaveProperty("coinCost");
+			expect(result).toHaveProperty("debtCost");
+			expect(result).toHaveProperty("hasPotion");
+			expect(result).toHaveProperty("modifier");
+		});
+	});
+});
+
+describe("compareParsedCosts", () => {
+	it.each([
+		{ costA: "cost$04", costB: "cost$05", desc: "sorts simple coin costs numerically" },
+		{ costA: "cost$03", costB: "cost$03P", desc: "sorts potion costs after regular costs" },
+		{ costA: "cost$02", costB: "cost$02+", desc: "sorts variable costs with + after fixed costs" },
+		{ costA: "cost$06*", costB: "cost$06+", desc: "sorts variable costs with * before +" },
+		{ costA: "cost$00", costB: "cost$0008D", desc: "sorts debt costs after zero coin cost" },
+		{ costA: "cost$04", costB: "cost$0403D", desc: "sorts mixed coin+debt after regular coin cost" },
+	])("$desc", ({ costA, costB }) => {
+		const parsedA = parseCostString(costA);
+		const parsedB = parseCostString(costB);
+		expect(parsedA && parsedB && compareParsedCosts(parsedA, parsedB) < 0).toBe(true);
+	});
+
+	it("sorts entire list of parsed cost classes correctly", () => {
+		const parsedCosts = WIKI_COST_CLASSES.map((costClass) => ({
+			original: costClass,
+			parsed: parseCostString(costClass),
+		})).filter((item) => item.parsed !== null);
+
+		const sortedCosts = parsedCosts.sort((a, b) => {
+			if (!a.parsed || !b.parsed) throw new Error("failed to parse cost class");
+			return compareParsedCosts(a.parsed, b.parsed);
+		});
+
+		const sortedOriginals = sortedCosts.map((item) => item.original);
+		expect(sortedOriginals).toEqual([
+			"cost",
+			"cost$00",
+			"cost$00*",
+			"cost$0004D",
+			"cost$0005D",
+			"cost$0006D",
+			"cost$0008D",
+			"cost$00P",
+			"cost$01",
+			"cost$02",
+			"cost$02*",
+			"cost$02+",
+			"cost$02P",
+			"cost$03",
+			"cost$03*",
+			"cost$03+",
+			"cost$03P",
+			"cost$04",
+			"cost$04*",
+			"cost$04+",
+			"cost$0403D",
+			"cost$04P",
+			"cost$05",
+			"cost$05*",
+			"cost$06",
+			"cost$06*",
+			"cost$06P",
+			"cost$07",
+			"cost$07*",
+			"cost$08",
+			"cost$08*",
+			"cost$0808D",
+			"cost$09",
+			"cost$10",
+			"cost$11",
+			"cost$14",
+		]);
+	});
+});

--- a/src/wiki/cards/cost-parser.ts
+++ b/src/wiki/cards/cost-parser.ts
@@ -1,0 +1,64 @@
+/**
+ * Represents parsed cost information from a Dominion card cost CSS class
+ */
+export type CardCost = {
+	coinCost: number;
+	debtCost: number;
+	hasPotion: boolean;
+	modifier: "*" | "+" | null;
+};
+
+/**
+ * Compares two ParsedCost objects for sorting purposes.
+ * Returns negative value if a should come before b, positive if b should come before a, 0 if equal.
+ * @param {CardCost} a - First cost to compare
+ * @param {CardCost} b - Second cost to compare
+ * @returns {number} Comparison result (-1, 0, or 1)
+ */
+export function compareParsedCosts(a: CardCost, b: CardCost): number {
+	if (a.coinCost !== b.coinCost) {
+		return a.coinCost - b.coinCost;
+	}
+
+	if (a.hasPotion !== b.hasPotion) {
+		return a.hasPotion ? 1 : -1;
+	}
+
+	if (a.debtCost !== b.debtCost) {
+		return a.debtCost - b.debtCost;
+	}
+
+	if (a.modifier !== b.modifier) {
+		if (!a.modifier && !b.modifier) return 0;
+		if (!a.modifier) return -1;
+		if (!b.modifier) return 1;
+		return a.modifier.localeCompare(b.modifier);
+	}
+
+	return 0;
+}
+
+/**
+ * Parses cost information from CSS class names using Dominion cost pattern.
+ * Takes multiple strings and returns structured cost data for the first one that matches
+ * the cost pattern, or null if none match.
+ *
+ * @param {...string} strings - CSS class names to check for cost patterns
+ * @returns {CardCost | null} Parsed cost data or null if no cost pattern found
+ */
+export function parseCostString(...strings: string[]): CardCost | null {
+	const reCost = /^cost(\$)?(\d\d)?([*+])?((\d\d)[Dd])?([Pp])?$/i;
+
+	for (const str of strings) {
+		const foundCost = str.match(reCost);
+		if (foundCost) {
+			const coinCost = foundCost[2] ? Number.parseInt(foundCost[2]) : 0;
+			const debtCost = foundCost[5] ? Number.parseInt(foundCost[5]) : 0;
+			const hasPotion = foundCost[6] !== undefined;
+			const modifier = (foundCost[3] as "*" | "+" | undefined) ?? null;
+			return { coinCost, debtCost, hasPotion, modifier };
+		}
+	}
+
+	return null;
+}


### PR DESCRIPTION
This PR extracts cost parsing into a test suite that includes unit tests and a `CardCost` type that's easier to work with.

- Extract card cost parsing into `cost-parser` and add complete unit test suite
- Integrate new cost parser into sorting workflow
- Rename `same(Set|Cost)` -> `allCardsHaveSame(Set|Cost)` variables for better readability
- Update Claude Code settings to allow codebase edits
- Fix issues with cache and scraper imports