### PR TITLE
fix: landscape sorting order

### DIFF
--- a/src/wiki/cards/sorting.test.ts
+++ b/src/wiki/cards/sorting.test.ts
@@ -9,71 +9,316 @@ function card(name: string, kind: CardKind = CardKind.Card, set: string = "", co
 	return { kind, name, set, cost, element };
 }
 
+const CARD_LIBRARY = [
+	// Base Set
+	card("Village", CardKind.Card, "01", "cost$03"),
+	card("Smithy", CardKind.Card, "01", "cost$04"),
+	card("Witch", CardKind.Card, "01", "cost$05"),
+	card("Artisan", CardKind.Card, "01", "cost$06"),
+
+	// Empires
+	card("Catapult", CardKind.Card, "02", "cost$03"),
+	card("Temple", CardKind.Card, "02", "cost$04"),
+	card("Archive", CardKind.Card, "02", "cost$05"),
+	card("Arena", CardKind.Landscape, "02", "cost$00"),
+	card("Delve", CardKind.Landscape, "02", "cost$02"),
+	card("Ritual", CardKind.Landscape, "02", "cost$04"),
+
+	// Rising Sun
+	card("Aristocrat", CardKind.Card, "03", "cost$03"),
+	card("Alley", CardKind.Card, "03", "cost$04"),
+	card("Gold Mine", CardKind.Card, "03", "cost$05"),
+	card("Samurai", CardKind.Card, "03", "cost$06"),
+	card("Panic", CardKind.Landscape, "03", "cost$00"),
+	card("Amass", CardKind.Landscape, "03", "cost$02"),
+	card("Sea Trade", CardKind.Landscape, "03", "cost$04"),
+];
+
 describe("sortCards", () => {
-	it("sorts cards by cost then name", () => {
-		const cards = [
-			card("Witch", CardKind.Card, "01", "cost$05"),
-			card("Adventurer", CardKind.Card, "01", "cost$06"),
-			card("Bridge", CardKind.Card, "01", "cost$04"),
-			card("Bandit", CardKind.Card, "01", "cost$05"),
-		];
+	describe("when not sorting by set", () => {
+		const bySet = false;
 
-		const sorted = sortCards(cards, SortBy.Cost, false);
-		expect(sorted.map((c) => c.name)).toEqual([
-			"Bridge", // 4 cost
-			"Bandit", // 5 cost (alphabetically first)
-			"Witch", // 5 cost (alphabetically second)
-			"Adventurer", // 6 cost
-		]);
+		describe("when sorting by name", () => {
+			const sortBy = SortBy.Name;
+
+			it("sorts cards as expected", () => {
+				const sorted = sortCards(CARD_LIBRARY, sortBy, bySet);
+				expect(sorted.map((c) => c.name)).toEqual([
+					// Cards
+					"Alley",
+					"Archive",
+					"Aristocrat",
+					"Artisan",
+					"Catapult",
+					"Gold Mine",
+					"Samurai",
+					"Smithy",
+					"Temple",
+					"Village",
+					"Witch",
+					// Landscapes
+					"Amass",
+					"Arena",
+					"Delve",
+					"Panic",
+					"Ritual",
+					"Sea Trade",
+				]);
+			});
+		});
+
+		describe("when sorting by cost", () => {
+			const sortBy = SortBy.Cost;
+
+			it("sorts cards as expected", () => {
+				const sorted = sortCards(CARD_LIBRARY, sortBy, bySet);
+				expect(sorted.map((c) => c.name)).toEqual([
+					// Cards
+					// 3 cost
+					"Aristocrat",
+					"Catapult",
+					"Village",
+					// 4 cost
+					"Alley",
+					"Smithy",
+					"Temple",
+					// 5 cost
+					"Archive",
+					"Gold Mine",
+					"Witch",
+					// 6 cost
+					"Artisan",
+					"Samurai",
+
+					// Landscapes
+					// 0 cost
+					"Arena",
+					"Panic",
+					// 2 cost
+					"Amass",
+					"Delve",
+					// 4 cost
+					"Ritual",
+					"Sea Trade",
+				]);
+			});
+		});
 	});
 
-	it("sorts landscape cards after portrait cards", () => {
-		const cards = [
-			card("Landscape", CardKind.Landscape, "01", "cost$04"),
-			card("Portrait", CardKind.Card, "01", "cost$04"),
-		];
+	describe("when sorting by set", () => {
+		const bySet = true;
 
-		const sorted = sortCards(cards, SortBy.Cost, false);
-		expect(sorted.map((c) => c.name)).toEqual(["Portrait", "Landscape"]);
+		describe("when sorting by name", () => {
+			const sortBy = SortBy.Name;
+
+			it("sorts cards as expected", () => {
+				const sorted = sortCards(CARD_LIBRARY, sortBy, bySet);
+				expect(sorted.map((c) => c.name)).toEqual([
+					// Base
+					"Artisan",
+					"Smithy",
+					"Village",
+					"Witch",
+
+					// Empires
+					// Cards
+					"Archive",
+					"Catapult",
+					"Temple",
+					// Landscapes
+					"Arena",
+					"Delve",
+					"Ritual",
+
+					// Rising Sun
+					// Cards
+					"Alley",
+					"Aristocrat",
+					"Gold Mine",
+					"Samurai",
+					// Landscapes
+					"Amass",
+					"Panic",
+					"Sea Trade",
+				]);
+			});
+		});
+
+		describe("when sorting by cost", () => {
+			const sortBy = SortBy.Cost;
+
+			it("sorts cards as expected", () => {
+				const sorted = sortCards(CARD_LIBRARY, sortBy, bySet);
+				expect(sorted.map((c) => c.name)).toEqual([
+					// Base
+					// 3 cost
+					"Village",
+					// 4 cost
+					"Smithy",
+					// 5 cost
+					"Witch",
+					// 6 cost
+					"Artisan",
+
+					// Empires
+					// Cards
+					// 3 cost
+					"Catapult",
+					// 4 cost
+					"Temple",
+					// 5 cost
+					"Archive",
+					// Landscapes
+					// 0 cost
+					"Arena",
+					// 2 cost
+					"Delve",
+					// 4 cost
+					"Ritual",
+
+					// Rising Sun
+					// Cards
+					// 3 cost
+					"Aristocrat",
+					// 4 cost
+					"Alley",
+					// 5 cost
+					"Gold Mine",
+					// 6 cost
+					"Samurai",
+					// Landscapes
+					// 0 cost
+					"Panic",
+					// 2 cost
+					"Amass",
+					// 4 cost
+					"Sea Trade",
+				]);
+			});
+		});
+	});
+});
+
+describe("sortCards (legacy tests)", () => {
+	describe("when sorting by name", () => {
+		it("sorts landscapes after cards", () => {
+			const cards = [
+				card("Way of the Butterfly", CardKind.Landscape),
+				card("Artisan", CardKind.Card),
+				card("Druid's Blessing", CardKind.Landscape),
+				card("Chapel", CardKind.Card),
+			];
+
+			const sorted = sortCards(cards, SortBy.Name, false);
+			expect(sorted.map((c) => c.name)).toEqual([
+				"Artisan", // Card, alphabetically first
+				"Chapel", // Card, alphabetically second
+				"Druid's Blessing", // Landscape, alphabetically first
+				"Way of the Butterfly", // Landscape, alphabetically second
+			]);
+		});
 	});
 
-	it("handles cards with null costs", () => {
-		const cards = [card("NoCost", CardKind.Card), card("WithCost", CardKind.Card, "01", "cost$03")];
+	describe("when sorting by cost", () => {
+		it("sorts cards by cost then name", () => {
+			const cards = [
+				card("Witch", CardKind.Card, "01", "cost$05"),
+				card("Adventurer", CardKind.Card, "01", "cost$06"),
+				card("Bridge", CardKind.Card, "01", "cost$04"),
+				card("Bandit", CardKind.Card, "01", "cost$05"),
+			];
 
-		const sorted = sortCards(cards, SortBy.Cost, false);
-		expect(sorted.map((c) => c.name)).toEqual([
-			"NoCost", // Null cost treated as zero cost
-			"WithCost", // 3 cost
-		]);
-	});
+			const sorted = sortCards(cards, SortBy.Cost, false);
+			expect(sorted.map((c) => c.name)).toEqual([
+				"Bridge", // 4 cost
+				"Bandit", // 5 cost (alphabetically first)
+				"Witch", // 5 cost (alphabetically second)
+				"Adventurer", // 6 cost
+			]);
+		});
 
-	it("groups by set when groupSets is true", () => {
-		const cards = [
-			card("Masquerade", CardKind.Card, "02", "cost$03"),
-			card("Artisan", CardKind.Card, "01", "cost$06"),
-			card("Bridge", CardKind.Card, "02", "cost$04"),
-		];
+		it("sorts landscape cards after portrait cards", () => {
+			const cards = [
+				card("Landscape", CardKind.Landscape, "01", "cost$04"),
+				card("Portrait", CardKind.Card, "01", "cost$04"),
+			];
 
-		const sorted = sortCards(cards, SortBy.Cost, true);
-		expect(sorted.map((c) => c.name)).toEqual([
-			"Artisan", // Set 01
-			"Masquerade", // Set 02, lower cost
-			"Bridge", // Set 02, higher cost
-		]);
-	});
+			const sorted = sortCards(cards, SortBy.Cost, false);
+			expect(sorted.map((c) => c.name)).toEqual(["Portrait", "Landscape"]);
+		});
 
-	it("ignores set grouping when groupSets is false", () => {
-		const cards = [
-			card("Shanty Town", CardKind.Card, "02", "cost$03"),
-			card("Bureaucrat", CardKind.Card, "01", "cost$04"),
-			card("Duke", CardKind.Card, "02", "cost$05"),
-		];
+		it("sorts landscapes after cards with mixed card types", () => {
+			const cards = [
+				card("Expensive Landscape", CardKind.Landscape, "01", "cost$06"),
+				card("Cheap Card", CardKind.Card, "01", "cost$02"),
+				card("Medium Landscape", CardKind.Landscape, "01", "cost$04"),
+				card("Expensive Card", CardKind.Card, "01", "cost$06"),
+			];
 
-		const sorted = sortCards(cards, SortBy.Cost, false);
-		expect(sorted.map((c) => c.name)).toEqual([
-			"Shanty Town", // 3 cost
-			"Bureaucrat", // 4 cost
-			"Duke", // 5 cost
-		]);
+			const sorted = sortCards(cards, SortBy.Cost, false);
+			expect(sorted.map((c) => c.name)).toEqual([
+				"Cheap Card", // 2 cost card
+				"Expensive Card", // 6 cost card (comes before landscapes of same cost)
+				"Medium Landscape", // 4 cost landscape
+				"Expensive Landscape", // 6 cost landscape
+			]);
+		});
+
+		it("handles cards with null costs", () => {
+			const cards = [card("NoCost", CardKind.Card), card("WithCost", CardKind.Card, "01", "cost$03")];
+
+			const sorted = sortCards(cards, SortBy.Cost, false);
+			expect(sorted.map((c) => c.name)).toEqual([
+				"NoCost", // Null cost treated as zero cost
+				"WithCost", // 3 cost
+			]);
+		});
+
+		it("groups by set when groupSets is true", () => {
+			const cards = [
+				card("Masquerade", CardKind.Card, "02", "cost$03"),
+				card("Artisan", CardKind.Card, "01", "cost$06"),
+				card("Bridge", CardKind.Card, "02", "cost$04"),
+			];
+
+			const sorted = sortCards(cards, SortBy.Cost, true);
+			expect(sorted.map((c) => c.name)).toEqual([
+				"Artisan", // Set 01
+				"Masquerade", // Set 02, lower cost
+				"Bridge", // Set 02, higher cost
+			]);
+		});
+
+		it("ignores set grouping when groupSets is false", () => {
+			const cards = [
+				card("Shanty Town", CardKind.Card, "02", "cost$03"),
+				card("Bureaucrat", CardKind.Card, "01", "cost$04"),
+				card("Duke", CardKind.Card, "02", "cost$05"),
+			];
+
+			const sorted = sortCards(cards, SortBy.Cost, false);
+			expect(sorted.map((c) => c.name)).toEqual([
+				"Shanty Town", // 3 cost
+				"Bureaucrat", // 4 cost
+				"Duke", // 5 cost
+			]);
+		});
+
+		it("maintains landscape after card ordering when grouping by set", () => {
+			const cards = [
+				card("Set2 Landscape", CardKind.Landscape, "02", "cost$03"),
+				card("Set1 Card", CardKind.Card, "01", "cost$03"),
+				card("Set2 Card", CardKind.Card, "02", "cost$03"),
+				card("Set1 Landscape", CardKind.Landscape, "01", "cost$03"),
+			];
+
+			const sorted = sortCards(cards, SortBy.Cost, true);
+			expect(sorted.map((c) => c.name)).toEqual([
+				"Set1 Card", // Set 01, card
+				"Set1 Landscape", // Set 01, landscape
+				"Set2 Card", // Set 02, card
+				"Set2 Landscape", // Set 02, landscape
+			]);
+		});
 	});
 });

--- a/src/wiki/cards/sorting.ts
+++ b/src/wiki/cards/sorting.ts
@@ -47,12 +47,6 @@ export const ZERO_COST_CARD: CardCost = { coinCost: 0, debtCost: 0, hasPotion: f
  */
 export function sortCards(cards: Card[], sortBy: SortBy, groupSets: boolean): Card[] {
 	const sortedCards = [...cards];
-
-	if (sortBy === SortBy.Name) {
-		sortedCards.sort((a, b) => a.name.localeCompare(b.name));
-		return sortedCards;
-	}
-
 	sortedCards.sort((a, b) => {
 		if (groupSets) {
 			const setComparison = a.set.localeCompare(b.set);
@@ -63,8 +57,10 @@ export function sortCards(cards: Card[], sortBy: SortBy, groupSets: boolean): Ca
 			return a.kind === CardKind.Landscape ? 1 : -1;
 		}
 
-		const costComparison = compareParsedCosts(a.cost || ZERO_COST_CARD, b.cost || ZERO_COST_CARD);
-		if (costComparison !== 0) return costComparison;
+		if (sortBy === SortBy.Cost) {
+			const costComparison = compareParsedCosts(a.cost || ZERO_COST_CARD, b.cost || ZERO_COST_CARD);
+			if (costComparison !== 0) return costComparison;
+		}
 
 		return a.name.localeCompare(b.name);
 	});


### PR DESCRIPTION
When I refactored the card sorting logic, I broke the logic behind sorting landscapes after cards in the "sort by name" case. I've updated this so that the logic is as follows:

- if grouping by sets, sort by set first
- then, sort by kind (card, then landscape)
- if sorting by cost, sort by cost next
- finally, sort by name

I've also added a comprehensive test that shows how each combination of (sort by name/cost, sort by set) works.