### PR TITLE
Fix sorting

### DIFF
--- a/src/wiki/cards/cost-parser.test.ts
+++ b/src/wiki/cards/cost-parser.test.ts
@@ -88,7 +88,7 @@ describe("parseCostString", () => {
 		{
 			desc: "cost with no coin amount",
 			input: "cost",
-			expected: { coinCost: 0, debtCost: 0, hasPotion: false, modifier: null },
+			expected: { coinCost: null, debtCost: 0, hasPotion: false, modifier: null },
 		},
 		{
 			desc: "zero cost",

--- a/src/wiki/cards/cost-parser.test.ts
+++ b/src/wiki/cards/cost-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { compareParsedCosts, parseCostString } from "./cost-parser.js";
+import { compareCardCosts, parseCostString } from "./cost-parser.js";
 
 // Scraped from all expansion pages on the wiki on 2025-08-16
 const WIKI_COST_CLASSES = [
@@ -111,7 +111,7 @@ describe("parseCostString", () => {
 	});
 });
 
-describe("compareParsedCosts", () => {
+describe("compareCardCosts", () => {
 	it.each([
 		{ costA: "cost$04", costB: "cost$05", desc: "sorts simple coin costs numerically" },
 		{ costA: "cost$03", costB: "cost$03P", desc: "sorts potion costs after regular costs" },
@@ -122,18 +122,18 @@ describe("compareParsedCosts", () => {
 	])("$desc", ({ costA, costB }) => {
 		const parsedA = parseCostString(costA);
 		const parsedB = parseCostString(costB);
-		expect(parsedA && parsedB && compareParsedCosts(parsedA, parsedB) < 0).toBe(true);
+		expect(parsedA && parsedB && compareCardCosts(parsedA, parsedB) < 0).toBe(true);
 	});
 
 	it("sorts entire list of parsed cost classes correctly", () => {
-		const parsedCosts = WIKI_COST_CLASSES.map((costClass) => ({
+		const CardCosts = WIKI_COST_CLASSES.map((costClass) => ({
 			original: costClass,
 			parsed: parseCostString(costClass),
 		})).filter((item) => item.parsed !== null);
 
-		const sortedCosts = parsedCosts.sort((a, b) => {
+		const sortedCosts = CardCosts.sort((a, b) => {
 			if (!a.parsed || !b.parsed) throw new Error("failed to parse cost class");
-			return compareParsedCosts(a.parsed, b.parsed);
+			return compareCardCosts(a.parsed, b.parsed);
 		});
 
 		const sortedOriginals = sortedCosts.map((item) => item.original);

--- a/src/wiki/cards/cost-parser.ts
+++ b/src/wiki/cards/cost-parser.ts
@@ -6,22 +6,14 @@ export type CardCost = {
 	modifier: "*" | "+" | null;
 };
 
-/** Costless cards have no coin cost listed (not even 0 coins) and cannot be purchased */
-const COSTLESS_CARD: CardCost = {
-	coinCost: null,
-	debtCost: 0,
-	hasPotion: false,
-	modifier: null,
-};
-
 /**
- * Compares two ParsedCost objects for sorting purposes.
+ * Compares two CardCost objects for sorting purposes.
  * Returns negative value if a should come before b, positive if b should come before a, 0 if equal.
  * @param {CardCost} a - First cost to compare
  * @param {CardCost} b - Second cost to compare
  * @returns {number} Comparison result (-1, 0, or 1)
  */
-export function compareParsedCosts(a: CardCost, b: CardCost): number {
+export function compareCardCosts(a: CardCost, b: CardCost): number {
 	if (a.coinCost !== b.coinCost) {
 		if (a.coinCost === null) return -1;
 		if (b.coinCost === null) return 1;
@@ -60,9 +52,12 @@ export function parseCostString(...strings: string[]): CardCost | null {
 	for (const str of strings) {
 		const foundCost = str.match(reCost);
 		if (foundCost) {
-			if (!foundCost.includes("$")) return COSTLESS_CARD;
-
-			const coinCost = foundCost[2] ? Number.parseInt(foundCost[2]) : 0;
+			const hasDollarSign = Boolean(foundCost[1]);
+			const coinCost = (() => {
+				if (!hasDollarSign) return null;
+				if (foundCost[2]) return Number.parseInt(foundCost[2]);
+				return 0;
+			})();
 			const debtCost = foundCost[5] ? Number.parseInt(foundCost[5]) : 0;
 			const hasPotion = foundCost[6] !== undefined;
 			const modifier = (foundCost[3] as "*" | "+" | undefined) ?? null;

--- a/src/wiki/cards/cost-parser.ts
+++ b/src/wiki/cards/cost-parser.ts
@@ -1,11 +1,17 @@
-/**
- * Represents parsed cost information from a Dominion card cost CSS class
- */
+/** Represents parsed cost information from a Dominion card cost CSS class */
 export type CardCost = {
-	coinCost: number;
+	coinCost: number | null;
 	debtCost: number;
 	hasPotion: boolean;
 	modifier: "*" | "+" | null;
+};
+
+/** Costless cards have no coin cost listed (not even 0 coins) and cannot be purchased */
+const COSTLESS_CARD: CardCost = {
+	coinCost: null,
+	debtCost: 0,
+	hasPotion: false,
+	modifier: null,
 };
 
 /**
@@ -17,6 +23,8 @@ export type CardCost = {
  */
 export function compareParsedCosts(a: CardCost, b: CardCost): number {
 	if (a.coinCost !== b.coinCost) {
+		if (a.coinCost === null) return -1;
+		if (b.coinCost === null) return 1;
 		return a.coinCost - b.coinCost;
 	}
 
@@ -52,6 +60,8 @@ export function parseCostString(...strings: string[]): CardCost | null {
 	for (const str of strings) {
 		const foundCost = str.match(reCost);
 		if (foundCost) {
+			if (!foundCost.includes("$")) return COSTLESS_CARD;
+
 			const coinCost = foundCost[2] ? Number.parseInt(foundCost[2]) : 0;
 			const debtCost = foundCost[5] ? Number.parseInt(foundCost[5]) : 0;
 			const hasPotion = foundCost[6] !== undefined;

--- a/src/wiki/cards/cost-parser.ts
+++ b/src/wiki/cards/cost-parser.ts
@@ -15,6 +15,7 @@ export type CardCost = {
  */
 export function compareCardCosts(a: CardCost, b: CardCost): number {
 	if (a.coinCost !== b.coinCost) {
+		// Costless cards are sorted before zero-cost cards
 		if (a.coinCost === null) return -1;
 		if (b.coinCost === null) return 1;
 		return a.coinCost - b.coinCost;

--- a/src/wiki/cards/sorting.test.ts
+++ b/src/wiki/cards/sorting.test.ts
@@ -114,29 +114,28 @@ describe("sortCards", () => {
 			it("sorts cards as expected", () => {
 				const sorted = sortCards(CARD_LIBRARY, sortBy, bySet);
 				expect(sorted.map((c) => c.name)).toEqual([
+					// Cards
 					// Base
 					"Artisan",
 					"Smithy",
 					"Village",
 					"Witch",
-
 					// Empires
-					// Cards
 					"Archive",
 					"Catapult",
 					"Temple",
-					// Landscapes
-					"Arena",
-					"Delve",
-					"Ritual",
-
 					// Rising Sun
-					// Cards
 					"Alley",
 					"Aristocrat",
 					"Gold Mine",
 					"Samurai",
+
 					// Landscapes
+					// Empires
+					"Arena",
+					"Delve",
+					"Ritual",
+					// Rising Sun
 					"Amass",
 					"Panic",
 					"Sea Trade",
@@ -150,6 +149,7 @@ describe("sortCards", () => {
 			it("sorts cards as expected", () => {
 				const sorted = sortCards(CARD_LIBRARY, sortBy, bySet);
 				expect(sorted.map((c) => c.name)).toEqual([
+					// Cards
 					// Base
 					// 3 cost
 					"Village",
@@ -161,23 +161,14 @@ describe("sortCards", () => {
 					"Artisan",
 
 					// Empires
-					// Cards
 					// 3 cost
 					"Catapult",
 					// 4 cost
 					"Temple",
 					// 5 cost
 					"Archive",
-					// Landscapes
-					// 0 cost
-					"Arena",
-					// 2 cost
-					"Delve",
-					// 4 cost
-					"Ritual",
 
 					// Rising Sun
-					// Cards
 					// 3 cost
 					"Aristocrat",
 					// 4 cost
@@ -186,7 +177,16 @@ describe("sortCards", () => {
 					"Gold Mine",
 					// 6 cost
 					"Samurai",
+
 					// Landscapes
+					// Empires
+					// 0 cost
+					"Arena",
+					// 2 cost
+					"Delve",
+					// 4 cost
+					"Ritual",
+					// Rising Sun
 					// 0 cost
 					"Panic",
 					// 2 cost
@@ -306,17 +306,17 @@ describe("sortCards (legacy tests)", () => {
 
 		it("maintains landscape after card ordering when grouping by set", () => {
 			const cards = [
-				card("Set2 Landscape", CardKind.Landscape, "02", "cost$03"),
 				card("Set1 Card", CardKind.Card, "01", "cost$03"),
 				card("Set2 Card", CardKind.Card, "02", "cost$03"),
 				card("Set1 Landscape", CardKind.Landscape, "01", "cost$03"),
+				card("Set2 Landscape", CardKind.Landscape, "02", "cost$03"),
 			];
 
 			const sorted = sortCards(cards, SortBy.Cost, true);
 			expect(sorted.map((c) => c.name)).toEqual([
 				"Set1 Card", // Set 01, card
-				"Set1 Landscape", // Set 01, landscape
 				"Set2 Card", // Set 02, card
+				"Set1 Landscape", // Set 01, landscape
 				"Set2 Landscape", // Set 02, landscape
 			]);
 		});

--- a/src/wiki/cards/sorting.test.ts
+++ b/src/wiki/cards/sorting.test.ts
@@ -20,7 +20,7 @@ const CARD_LIBRARY = [
 	card("Catapult", CardKind.Card, "02", "cost$03"),
 	card("Temple", CardKind.Card, "02", "cost$04"),
 	card("Archive", CardKind.Card, "02", "cost$05"),
-	card("Arena", CardKind.Landscape, "02", "cost$00"),
+	card("Arena", CardKind.Landscape, "02", "cost"),
 	card("Delve", CardKind.Landscape, "02", "cost$02"),
 	card("Ritual", CardKind.Landscape, "02", "cost$04"),
 
@@ -29,7 +29,7 @@ const CARD_LIBRARY = [
 	card("Alley", CardKind.Card, "03", "cost$04"),
 	card("Gold Mine", CardKind.Card, "03", "cost$05"),
 	card("Samurai", CardKind.Card, "03", "cost$06"),
-	card("Panic", CardKind.Landscape, "03", "cost$00"),
+	card("Panic", CardKind.Landscape, "03", "cost"),
 	card("Amass", CardKind.Landscape, "03", "cost$02"),
 	card("Sea Trade", CardKind.Landscape, "03", "cost$04"),
 ];

--- a/src/wiki/cards/sorting.ts
+++ b/src/wiki/cards/sorting.ts
@@ -1,5 +1,5 @@
 import { getCookie, setCookie } from "../core/cookies";
-import { type CardCost, compareParsedCosts, parseCostString } from "./cost-parser";
+import { type CardCost, compareCardCosts, parseCostString } from "./cost-parser";
 
 /** Sort method for card galleries */
 export enum SortBy {
@@ -58,7 +58,7 @@ export function sortCards(cards: Card[], sortBy: SortBy, groupSets: boolean): Ca
 		}
 
 		if (sortBy === SortBy.Cost) {
-			const costComparison = compareParsedCosts(a.cost || ZERO_COST_CARD, b.cost || ZERO_COST_CARD);
+			const costComparison = compareCardCosts(a.cost || ZERO_COST_CARD, b.cost || ZERO_COST_CARD);
 			if (costComparison !== 0) return costComparison;
 		}
 

--- a/src/wiki/cards/sorting.ts
+++ b/src/wiki/cards/sorting.ts
@@ -48,13 +48,13 @@ export const ZERO_COST_CARD: CardCost = { coinCost: 0, debtCost: 0, hasPotion: f
 export function sortCards(cards: Card[], sortBy: SortBy, groupSets: boolean): Card[] {
 	const sortedCards = [...cards];
 	sortedCards.sort((a, b) => {
+		if (a.kind !== b.kind) {
+			return a.kind === CardKind.Landscape ? 1 : -1;
+		}
+
 		if (groupSets) {
 			const setComparison = a.set.localeCompare(b.set);
 			if (setComparison !== 0) return setComparison;
-		}
-
-		if (a.kind !== b.kind) {
-			return a.kind === CardKind.Landscape ? 1 : -1;
 		}
 
 		if (sortBy === SortBy.Cost) {


### PR DESCRIPTION
- Fix sorting logic:
  - Landscapes are always sorted after Cards because mixing landscapes and cards causes layout issues in the current gallery
  - Cards with no costs are sorted before zero-cost cards
- Update tests to match new sorting logic
- Rename ParsedCost stuff to CardCost to match existing types/methods
