### PR TITLE
fix: only use first line of commit message for mediawiki changelog

### DIFF
--- a/src/scripts/deploy-to-mediawiki.ts
+++ b/src/scripts/deploy-to-mediawiki.ts
@@ -71,9 +71,10 @@ function getGitCommitHash(): string {
 	return process.env.GITHUB_SHA || "unknown";
 }
 
-/** Get the commit message */
+/** Get the commit message title (first line only) */
 function getCommitMessage(): string {
-	return process.env.GITHUB_EVENT_HEAD_COMMIT_MESSAGE || "Unknown commit";
+	const fullMessage = process.env.GITHUB_EVENT_HEAD_COMMIT_MESSAGE || "Unknown commit";
+	return fullMessage.split("\n")[0];
 }
 
 /** Get the actor/author */


### PR DESCRIPTION
The current commit messages that arrive in MediaWiki changelogs via GitHubBot are too long. Trim to the first line only so they don't clip: 
<img width="793" height="680" alt="image" src="https://github.com/user-attachments/assets/095064f8-56bc-466d-9934-4912b37af9b0" />
