### PR TITLE
fix: cookies use same path

### DIFF
--- a/src/wiki/core/options.ts
+++ b/src/wiki/core/options.ts
@@ -43,7 +43,7 @@ async function getCookie(name: string): Promise<string | null> {
 async function setCookie(name: string, value: string | number): Promise<void> {
 	const cookieDate = new Date();
 	cookieDate.setFullYear(cookieDate.getFullYear() + COOKIE_EXPIRATION_YEARS);
-	await cookieStore.set({ name, value: String(value), expires: cookieDate.getTime(), sameSite: "strict" });
+	await cookieStore.set({ name, value: String(value), expires: cookieDate.getTime(), sameSite: "strict", path: "/" });
 	return;
 }
 


### PR DESCRIPTION
Site-wide cookies should use the same path so they apply across pages, as noted by [a commenter](https://wiki.dominionstrategy.com/index.php/MediaWiki_talk:Common.js#cookie_path).